### PR TITLE
Sending FAILED status in case of error

### DIFF
--- a/netconfdriver/config/default_config.yml
+++ b/netconfdriver/config/default_config.yml
@@ -4,3 +4,6 @@ application:
 
 messaging:
   connection_address: cp4na-o-events-kafka-bootstrap:9092
+
+resource_driver:
+  async_messaging_enabled: False


### PR DESCRIPTION
# Pull Request Review

## Checklist


- [x] Issue: https://github.com/IBM/netconf-driver/issues/11
- [x] List of related PRs : https://github.com/IBM/ignition/pull/153
- [x] Project builds without any errors.
- [x] Unit Tests - all pass.
- [x] Ran manual functional “smoke” test (does product as a whole still work?).
- [x] User Story meets the acceptance criteria - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**:  As of now Driver is only sending 'Complete' status when it is success but no 'FAILED' status when errors are occurring. This PR has been raised to to send 'FAILED' status in case of error. 