### PR TITLE
Enable SSL on netconf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,4 +27,5 @@ WORKDIR /home/netconfdriver
 
 EXPOSE 7139
 
-CMD gunicorn -w $NUM_PROCESSES -b :$DRIVER_PORT "netconfdriver:create_wsgi_app()"
+CMD if [ $SSL_ENABLED | tr [:upper:] [:lower:] == "true" ]; then SSL="--certfile /var/netconfdriver/certs/tls.crt --keyfile /var/netconfdriver/certs/tls.key" ; fi \
+&& gunicorn --workers $NUM_PROCESSES --bind :$DRIVER_PORT $SSL "netconfdriver:create_wsgi_app()"

--- a/helm/netconf-driver/templates/_helpers
+++ b/helm/netconf-driver/templates/_helpers
@@ -1,0 +1,8 @@
+{{/*
+Generate SSL certificate
+*/}}
+{{- define "gen-cert" -}}
+{{- $cert := genSelfSignedCert "netconf-driver" nil nil 3650 -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/helm/netconf-driver/templates/configmap.yaml
+++ b/helm/netconf-driver/templates/configmap.yaml
@@ -17,3 +17,4 @@ data:
 {{ toYaml .Values.app.config.env | indent 2 }}
 {{- end }}
   "LOG_LEVEL": {{ .Values.app.config.log.level }}
+  "SSL_ENABLED": {{ quote .Values.app.config.security.ssl.enabled }}

--- a/helm/netconf-driver/templates/tls-secret.yaml
+++ b/helm/netconf-driver/templates/tls-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.app.config.security.ssl.enabled .Values.app.config.security.ssl.secret.generate }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ .Values.app.config.security.ssl.secret.name }}
+  labels:
+    app: netconf-driver
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+{{ ( include "gen-cert" . ) | indent 2 }}
+{{- end }}

--- a/helm/netconf-driver/values.yaml
+++ b/helm/netconf-driver/values.yaml
@@ -46,7 +46,7 @@ app:
   
     security:
       ssl:
-        enabled: False
+        enabled: True
         secret:
           ## Name of the secret containing the SSL certificate for the non-host based access (the CN of the certificate should match commonName)
           name: netconf-driver-tls


### PR DESCRIPTION


- [x] Issue: Enable SSL on netconf driver #12
- [x] List of related PRs.
- [x] Project builds without any errors.
- [x] Unit Tests updated (or created where needed) and all pass.
- [x] You have ran manual functional “smoke” test (does product as a whole still work?).
- [x] User Story meets the acceptance criteria - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**: netconf Resource Driver must be installed with SSL enabled by default. 