### PR TITLE
Enable IPv6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,4 +28,4 @@ WORKDIR /home/netconfdriver
 EXPOSE 7139
 
 CMD if [ $SSL_ENABLED | tr [:upper:] [:lower:] == "true" ]; then SSL="--certfile /var/netconfdriver/certs/tls.crt --keyfile /var/netconfdriver/certs/tls.key" ; fi \
-&& gunicorn --workers $NUM_PROCESSES --bind :$DRIVER_PORT $SSL "netconfdriver:create_wsgi_app()"
+&& gunicorn --workers $NUM_PROCESSES --bind [::]:$DRIVER_PORT $SSL "netconfdriver:create_wsgi_app()"


### PR DESCRIPTION

- [x] Issue: Enable IPv6 on netconf #14 
- [x] List of related PRs.
- [x] Project builds without any errors.
- [x] Unit Tests updated (or created where needed) and all pass.
- [x] You have ran manual functional “smoke” test (does product as a whole still work?).
- [x] User Story meets the acceptance criteria - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**: Currently Netconf Driver is giving connection refused on ipV6 cluster. Need to enable IPv6 on netconf so that it works in IPv6 cluster.