### PR TITLE
Issue 16

### DIFF
--- a/netconfdriver/service/location/deployment_location.py
+++ b/netconfdriver/service/location/deployment_location.py
@@ -75,9 +75,9 @@ class NetConfDeploymentLocation:
             NetConfDeploymentLocation.TIMEOUT: self.timeout,
         }
 
-    def operation(self,package_properties,default_operation,rsa_key_path):
+    def operation(self,package_properties,default_operation,rsa_key_path,request_id):
         response = ConfigOperations.netconf_connect(self.host, self.port, self.username, self.password, rsa_key_path, self.kwargs)
-        edit_config_details = ConfigOperations.netconf_edit(response,package_properties,default_operation)
+        edit_config_details = ConfigOperations.netconf_edit(response,package_properties,default_operation,request_id)
         ConfigOperations.netconf_disconnect(response)
         return edit_config_details
 

--- a/netconfdriver/service/operations/config_operations.py
+++ b/netconfdriver/service/operations/config_operations.py
@@ -1,6 +1,8 @@
 import sys
 import logging
+import uuid
 from ncclient import manager
+from ignition.service.logging import logging_context
 logger = logging.getLogger(__name__)
     
 class NetconfConfigError(Exception):
@@ -25,9 +27,14 @@ class ConfigOperations():
             logger.error('Unexpected exception {0}'.format(e))
             raise NetconfConfigError(str(e)) from e
         
-    def netconf_edit(conn,package_properties,default_operation):
+    def netconf_edit(conn,package_properties,default_operation,request_id):
         try:
+            external_request_id = str(uuid.uuid4())
+            ConfigOperations._generate_additional_logs(package_properties, 'sent', external_request_id,
+                                       'message', 'rpc', {'operation' : default_operation}, request_id)
             edit_config_details = conn.edit_config(config=package_properties, target="running", default_operation=default_operation)
+            ConfigOperations._generate_additional_logs(edit_config_details, 'received', external_request_id,
+                                       'message', 'rpc', {'operation' : default_operation}, request_id)
             logger.debug('config_details = %s', edit_config_details)
             return edit_config_details
         except Exception as e:
@@ -41,3 +48,24 @@ class ConfigOperations():
         except Exception as e:
             logger.error('Unexpected exception {0}'.format(e))
             raise NetconfConfigError(str(e)) from e
+
+    def _generate_additional_logs(rpc, message_direction, external_request_id,
+                                  message_type, protocol, protocol_metadata, driver_request_id):
+        try:
+            logging_context_dict = {'message_direction' : message_direction, 'tracectx.externalrequestid' : external_request_id,
+                                    'message_type' : message_type, 'protocol' : protocol, 'protocol_metadata' : protocol_metadata, 'tracectx.driverrequestid' : driver_request_id}
+            logging_context.set_from_dict(logging_context_dict)
+            logger.info(rpc)
+        finally:
+            if('message_direction' in logging_context.data):
+                logging_context.data.pop("message_direction")
+            if('tracectx.externalrequestid' in logging_context.data):
+                logging_context.data.pop("tracectx.externalrequestid")
+            if('message_type' in logging_context.data):
+                logging_context.data.pop("message_type")
+            if('protocol' in logging_context.data):
+                logging_context.data.pop("protocol")
+            if('protocol_metadata' in logging_context.data):
+                logging_context.data.pop("protocol_metadata")
+            if('tracectx.driverrequestid' in logging_context.data):
+                logging_context.data.pop("tracectx.driverrequestid")

--- a/netconfdriver/service/resourcedriver.py
+++ b/netconfdriver/service/resourcedriver.py
@@ -1,4 +1,5 @@
-from ignition.model.lifecycle import LifecycleExecuteResponse, LifecycleExecution, STATUS_COMPLETE
+from ignition.model.failure import FAILURE_CODE_INTERNAL_ERROR, FailureDetails
+from ignition.model.lifecycle import STATUS_FAILED, LifecycleExecuteResponse, LifecycleExecution, STATUS_COMPLETE
 from ignition.service.framework import Service
 from ignition.service.resourcedriver import ResourceDriverHandlerCapability, ResourceDriverError, InvalidRequestError
 from ignition.service.framework import Service
@@ -32,6 +33,10 @@ class ResourceDriverHandler(Service, ResourceDriverHandlerCapability):
             ignition.service.resourcedriver.ResourceDriverError: there was an error handling this request
         """
         netconf_location = None
+
+        # setting default status as FAILED, if lifecycle gets successful then it is updated to SUCCESS
+        with open('lifecycle_status', 'w') as output:
+            output.write('FAILED')
         
         try:
             logger.info(f'lifecycle_name:{lifecycle_name},driver_files:{driver_files},deployment_location:{deployment_location}')
@@ -58,11 +63,21 @@ class ResourceDriverHandler(Service, ResourceDriverHandlerCapability):
             edit_config_details = netconf_location.operation(package_properties,default_operation,rsa_key_path)
             logger.info('RESPONSE: %s :- After Executing Operation , Result : %s', request_id, edit_config_details)
         except NetconfConfigError as e:
-            raise InvalidRequestError(str(e)) from e
+            failure_reason = f'Error related to Netconf Connection or Configuration. {e}'
+            logger.exception(failure_reason)            
+            with open('lifecycle_failure_reason', 'w') as output:
+                output.write(failure_reason)
+            return LifecycleExecution(request_id, STATUS_FAILED, FailureDetails(FAILURE_CODE_INTERNAL_ERROR, failure_reason), outputs={})
         except jinja_conversion.PropertyError as e:
-            raise ResourceDriverError(str(e)) from e
+            failure_reason = f'Error related to jinja_conversion. {e}'
+            logger.exception(failure_reason)            
+            with open('lifecycle_failure_reason', 'w') as output:
+                output.write(failure_reason)
+            return LifecycleExecution(request_id, STATUS_FAILED, FailureDetails(FAILURE_CODE_INTERNAL_ERROR, failure_reason), outputs={})
         else:
             os.unlink(rsa_key_path)
+            with open('lifecycle_status', 'w') as output:
+                output.write('SUCCESS')
             return LifecycleExecuteResponse(request_id)
 
     def get_lifecycle_execution(self, request_id, deployment_location):
@@ -76,8 +91,17 @@ class ResourceDriverHandler(Service, ResourceDriverHandlerCapability):
             ignition.service.resourcedriver.TemporaryResourceDriverError: there is an issue handling this request at this time, an attempt should be made again at a later time
             ignition.service.resourcedriver.ResourceDriverError: there was an error handling this request
         """
-
-        return LifecycleExecution(request_id, STATUS_COMPLETE, failure_details=None, outputs={})
+        status = ''
+        with open('lifecycle_status', 'r') as output:
+            status = output.read()
+            logger.info(f'lifecycle execution status : {status}')
+        if(status == 'SUCCESS'):
+            return LifecycleExecution(request_id, STATUS_COMPLETE, failure_details=None, outputs={})
+        else:
+            failure_reason = ''
+            with open('lifecycle_failure_reason', 'r') as output:
+                failure_reason = output.read()
+            return LifecycleExecution(request_id, STATUS_FAILED, FailureDetails(FAILURE_CODE_INTERNAL_ERROR, failure_reason), outputs={})
 
     def find_reference(self, instance_name, driver_files, deployment_location):
         """

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -84,7 +84,8 @@ class TestLifecycleController(unittest.TestCase):
         
 
     @patch.object(ConfigOperations, 'netconf_connect')
-    def test_driver(self,mock_request):
+    @patch.object(ConfigOperations, '_generate_additional_logs')
+    def test_driver(self,mock_request, mock_logs):
         system_properties = {}
         request_properties = self.__request_properties()
         deployment_location = self.__deployment_location()
@@ -100,3 +101,4 @@ class TestLifecycleController(unittest.TestCase):
                                     system_properties, resource_properties, 
                                     request_properties, associated_topology, deployment_location)
             mock_request.assert_called()
+            assert ConfigOperations._generate_additional_logs.called


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue:** https://github.com/IBM/netconf-driver/issues/16
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors.**
- [x] **Unit Tests** - all pass.
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** : Yes, QA has validated the dev image and everything is working fine. They have uploaded the test results in IBM internal user stories.
- [x] **User Story meets the acceptance criteria** - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**:  

Enable Logging for External Request & Response. Drivers will be updated to log specific messages with details of requests & responses they send and receive from external systems. Netconf driver makes rpc calls to a Netconf server. Each call is a request/response rpc message pair which the driver will log.