### PR TITLE
Issue 39 - Adding --pull for fetching latest base images

### DIFF
--- a/build.py
+++ b/build.py
@@ -251,7 +251,7 @@ class Builder:
                 print('Copying Ignition whl at {0} to {1}'.format(args.ignition_whl, dest_ign_whl))
                 shutil.copyfile(args.ignition_whl, dest_ign_whl)
             img_tag = '{0}:{1}'.format(docker_img_name, self.project_version)
-            s.run_cmd('docker', 'build', '-t', img_tag, '{0}'.format(docker_context_path))
+            s.run_cmd('docker', 'build', '--pull', '-t', img_tag, '{0}'.format(docker_context_path))
 
     def build_helm_chart(self):
         with self.stage('Build Helm Chart') as s:


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue** : https://github.com/IBM/netconf-driver/issues/39
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors**
- [x] **Unit Tests** : All passed
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** 
- [x] **User Story meets the acceptance criteria and passes**
- [x]  **Description of the changes**:  Fix CP4NA Vulnerability : expat - CVE-2022-43680 - High.
We are adding '--pull' in docker build command so that it pulls the latest base images which fixes vulnerabilities.